### PR TITLE
feat: implement card non editable

### DIFF
--- a/src/components/Forms/Card/Card.stories.tsx
+++ b/src/components/Forms/Card/Card.stories.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Meta, Story } from "@storybook/react";
+import { Card } from "./index";
+import { CardDashboardProps } from "../type";
+
+export default {
+  title: "Components/Form/Card",
+  component: Card,
+} as Meta;
+
+export const Uneditable: Story<CardDashboardProps> = (args) => {
+  args = {
+    header: "Profil Coach",
+    editable: false,
+    body: <div>Body</div>
+  }
+  return (
+    <Card>
+      <Card.Header>{args.header}</Card.Header>
+      <Card.Body>{args.body}</Card.Body>
+    </Card>
+  );
+};
+
+export const Editable: Story<CardDashboardProps> = (args) => {
+  return (
+    <></>
+  );
+}

--- a/src/components/Forms/Card/Card.tsx
+++ b/src/components/Forms/Card/Card.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { StyledCard } from "./style";
+import { DisplayNameUtils } from "../../../utils";
+
+const Card = ({ children }: { children: any}) => {
+  const header = DisplayNameUtils(children, "Header");
+  const body = DisplayNameUtils(children, "Body");
+
+  return (
+    <StyledCard>
+      <div className="card-header">{header}</div>
+      <div className="card-body">{body}</div>
+    </StyledCard>
+  );
+};
+
+const Header = ({ children }: { children: any}) => children;
+Header.displayName = "Header";
+Card.Header = Header;
+
+const Body = ({ children }:{ children: any}) => children;
+Body.displayName = "Body";
+Card.Body = Body;
+
+export default Card;

--- a/src/components/Forms/Card/index.ts
+++ b/src/components/Forms/Card/index.ts
@@ -1,0 +1,2 @@
+export * from "./Card";
+export { default as Card } from "./Card";

--- a/src/components/Forms/Card/style.ts
+++ b/src/components/Forms/Card/style.ts
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+export const StyledCard = styled.div`
+  overflow: hidden;
+  background-color: #ffffff;
+  border-radius: 1.25rem;
+  box-shadow: 0px 0px 6px #FFEEE5;  
+
+  .card-header {
+    color: #5CA898;
+    font-weight: 700;
+    background-color: #EDF9F6;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    padding: 1.125rem 1.5rem;
+  };
+
+  .card-body {
+    padding: 1.5rem;
+  };
+
+  @media (max-width: 768px) {
+    .card-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+    }
+  }
+`;

--- a/src/components/Forms/type.ts
+++ b/src/components/Forms/type.ts
@@ -9,4 +9,10 @@ export interface BaseControlledInputProps {
   >;
   defaultValue?: string | boolean | number;
   placeholder?: string;
+};
+
+export interface CardDashboardProps {
+  header?: string;
+  body?: any;
+  editable?: boolean;
 }

--- a/src/utils/DisplayNameUtils.tsx
+++ b/src/utils/DisplayNameUtils.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+
+export const getChildrenOnDisplayName = (children: any, displayName: any) =>
+  React.Children.map(children, (child) =>
+    child.type.displayName === displayName ? child : null
+  )
+
+export default getChildrenOnDisplayName;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,5 @@
 export * from "./ConnectForm";
 export { default as ConnectForm } from "./ConnectForm";
+
+export * from "./DisplayNameUtils";
+export { default as DisplayNameUtils } from "./DisplayNameUtils";


### PR DESCRIPTION
Implement Card in Dashboard(Care Portal) based on [Alceo](https://www.figma.com/file/wTk0kJaQbKIMOfUpgM9KBE/%F0%9F%8E%A8-%5BALCEO%5D-Desktop-Component?node-id=724%3A1743) documentation

- [x] Card non editable
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/98725806/177919232-ef5dd179-0c98-428e-a801-dd5c5863a102.png">

- [ ] Card Editable - Read View
- [ ] Card Editable - Edit View